### PR TITLE
SUP-46043 Fix archive data for non env licence in activity report

### DIFF
--- a/news/SUP-46043.bugfix
+++ b/news/SUP-46043.bugfix
@@ -1,0 +1,2 @@
+Fix archive data for non env licence in activity report
+[jchandelle]

--- a/src/liege/urban/browser/activity_report.py
+++ b/src/liege/urban/browser/activity_report.py
@@ -220,6 +220,14 @@ def extract_licence_dict(brain, streets_by_UID):
         licence_dict["external_address"] = extract_external_address(licence)
         licence_dict["external_parcels"] = extract_external_parcels(licence)
 
+    if licence.getLastSentToArchives():
+        licence_dict["archives_date"] = str(
+            licence.getLastSentToArchives().getEventDate() or ""
+        )
+        licence_dict["archives_description"] = (
+            str(licence.getLastSentToArchives().getMisc_description()) or ""
+        )
+
     if interfaces.IEnvironmentBase.providedBy(licence):
         licence_dict["authorization_start_date"] = licence.getLastLicenceEffectiveStart() and str(
             licence.getLastLicenceEffectiveStart().getEventDate() or ""
@@ -229,12 +237,6 @@ def extract_licence_dict(brain, streets_by_UID):
         )
         licence_dict["displaying_date"] = licence.getLastDisplayingTheDecision() and str(
             licence.getLastDisplayingTheDecision().getEventDate() or ""
-        )
-        licence_dict["archives_date"] = licence.getLastSentToArchives() and str(
-            licence.getLastSentToArchives().getEventDate() or ""
-        )
-        licence_dict["archives_description"] = (
-            licence.getLastSentToArchives() and str(licence.getLastSentToArchives().getMisc_description()) or ""
         )
         licence_dict["activity_ended_date"] = licence.getLastActivityEnded() and str(
             licence.getLastActivityEnded().getEventDate() or ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archive data display in activity reports for non-environment licenses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->