### PR TITLE
SUP-52803 Add empty value to `inquiry_category` field

### DIFF
--- a/news/SUP-52803.feature
+++ b/news/SUP-52803.feature
@@ -1,0 +1,2 @@
+Add empty value to `inquiry_category` field in `CODT_UniqueLicenceInquiry`
+[jchandelle]

--- a/src/liege/urban/__init__.py
+++ b/src/liege/urban/__init__.py
@@ -27,6 +27,7 @@ import liege.urban.content.portion_out
 import liege.urban.content.preliminarynotice
 import liege.urban.content.urbanevent
 import liege.urban.content.urbanevent_opinionrequest
+import liege.urban.content.CODT_UniqueLicenceInquiry
 import liege.urban.content.roaddecree  # noqa
 from liege.urban.config import LICENCE_FINAL_STATES
 

--- a/src/liege/urban/content/CODT_UniqueLicenceInquiry.py
+++ b/src/liege/urban/content/CODT_UniqueLicenceInquiry.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from Products.urban.content.CODT_UniqueLicenceInquiry import CODT_UniqueLicenceInquiry
+from Products.Archetypes.atapi import DisplayList
+
+
+def list_inquiry_category(self):
+    """ """
+    vocabulary = (
+        ("", "-- Choisissez --"),
+        ("B", "Catégorie B, rayon 200m (attention publication)"),
+        ("C", "Catégorie C, rayon 50m"),
+    )
+    return DisplayList(vocabulary)
+
+
+CODT_UniqueLicenceInquiry.list_inquiry_category = list_inquiry_category


### PR DESCRIPTION
 in `CODT_UniqueLicenceInquiry`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty/default value option for inquiry category selection.
  * Expanded inquiry category options with new choices available for selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->